### PR TITLE
fix: define process.versions.node for TW3 browser compiler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- [TW3] Browser compiler throws "Unable to determine current node version" [#78](https://github.com/wind-press/windpress/issues/78)
+
 ## [3.3.85] - 2026-06-18
 
 ### Added

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -90,6 +90,7 @@ export default defineConfig({
   },
   define: {
     __dirname: JSON.stringify("/"),
+    "process.versions.node": JSON.stringify("22.9.0"),
   },
   optimizeDeps: {
     exclude: ["@windpress/oxide-parser"],


### PR DESCRIPTION
## Summary

Defines `process.versions.node` via Vite's `define` config so it is inlined at compile time, preventing the Tailwind v3 browser compiler from throwing `TypeError: Unable to determine current node version`.

## Root cause

The `vite-plugin-node-polyfills` process shim sets `process.versions = {}` (empty object). When `resolve/lib/core.js` eagerly evaluates `isCoreModule()` for all Node core modules at module-load time, `is-core-module` reads `process.versions.node`, finds `undefined`, and throws:

```
TypeError: Unable to determine current node version
    at o2 (build-<hash>.js)
    at n2.exports (build-<hash>.js)
```

This breaks the Bricks editor live-compile and dashboard Generate Cache (both use the same TW3 bundle). TW4 is unaffected since it uses the oxide WASM parser.

## Fix

Added `"process.versions.node": JSON.stringify("22.9.0")` to the `define` config in `vite.config.ts`. Vite replaces all occurrences of `process.versions.node` with the literal string `"22.9.0"` at compile time, so the runtime check in `is-core-module` receives a valid version string and never hits the error path.

The existing `is-core-module` pnpm patch (`return true` before throw) is kept as an additional safety net.

Closes #78