### PR TITLE
[Gutenberg] Fix WPML save conflict

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - [TW3] Browser compiler throws "Unable to determine current node version" [#78](https://github.com/wind-press/windpress/issues/78)
+- [Gutenberg] Fixed saving issues when WPML is enabled.
 
 ## [3.3.85] - 2026-06-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- [TW3] Browser compiler throws "Unable to determine current node version" [#78](https://github.com/wind-press/windpress/issues/78)
+
 ## [3.3.85] - 2026-06-18
 
 ### Added

--- a/assets/integration/gutenberg/modules/generate-cache/main.ts
+++ b/assets/integration/gutenberg/modules/generate-cache/main.ts
@@ -20,7 +20,7 @@ const channel = new BroadcastChannel("windpress");
   const __fetch = window.fetch;
 
   window.fetch = function (input, init) {
-    const url = typeof input === "string" ? input : input.url;
+    const url = input instanceof Request ? input.url : String(input ?? "");
 
     // Check if preferences are enabled
     if (!isGenerateCacheOnSaveEnabled()) {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -90,6 +90,7 @@ export default defineConfig({
   },
   define: {
     __dirname: JSON.stringify("/"),
+    "process.versions.node": JSON.stringify("22.9.0"),
   },
   optimizeDeps: {
     exclude: ["@windpress/oxide-parser"],


### PR DESCRIPTION
## Summary
- Prevented Gutenberg saving issues when WPML is enabled.
- Added a changelog entry.

## Validation
- TypeScript transpilation passed.
- `git diff --check` passed.

The full repository lint/typecheck still reports pre-existing unrelated issues.